### PR TITLE
Changing react dependency to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "react": "^15.6.1",
     "recompose": "^0.24.0"
   },
   "devDependencies": {
@@ -25,6 +24,9 @@
     "babel-preset-stage-3": "^6.24.1",
     "rimraf": "^2.6.1",
     "standard": "^10.0.2"
+  },
+  "peerDependencies": {
+    "react": "^15.6.0 || ^16.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Hi @therealparmesh. We ran into an issue because flexin wants exactly 15.6.1 and we ended with 15.6.1 for flexin and 15.6.2 for our app. I think moving react to a peerDependency is the right fix. Can you take a look at these changes and if it looks good merge + release new version? If you need someone to do this add me to the flexin project and I can give it a shot :D

- Need to make the react dependency a peerDependency to ensure that flexin does not pull in a different version of react than the project that uses flexin.
- Also setting the dependency to be on the minor version of 15 (otherwise 15.6.2 does not suffice). And allowing 16 - why not?